### PR TITLE
Removed externalcl flag

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -85,5 +85,4 @@ exec erigon --datadir=${DATADIR} \
     --authrpc.jwtsecret=${JWT_PATH} \
     --authrpc.addr 0.0.0.0 \
     --authrpc.vhosts=* \
-    --externalcl \
     ${ERIGON_EXTRA_OPTS}


### PR DESCRIPTION
Erigon was throwing this error:
```{"error":{"name":"No DNP with ip 172.33.0.16","message":"No DNP with ip 172.33.0.16"}}Incorrect Usage: flag provided but not defined: -externalcl```