### PR TITLE
Avoid page size error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -85,4 +85,5 @@ exec erigon --datadir=${DATADIR} \
     --authrpc.jwtsecret=${JWT_PATH} \
     --authrpc.addr 0.0.0.0 \
     --authrpc.vhosts=* \
+    --db.size.limit=8TB \
     ${ERIGON_EXTRA_OPTS}


### PR DESCRIPTION
When updating Erigon from previous versions, installing the new version can lead to errors like:
```
mdbx_env_open: MDBX_TOO_LARGE: Database is too large for current system, e.g. could NOT be mapped into RAM, label: chaindata, trace: [kv_mdbx.go:352 node.go:365 node.go:368 backend.go:236 node.go:124 main.go:65 make_app.go:52 command.go:279 app.go:337 app.go:311 main.go:34 proc.go:267 asm_amd64.s:1650]
```

This is fixed by adding the flag `--db.size.limit=8TB` as explained here: https://github.com/ledgerwatch/erigon/releases/tag/v2.55.0